### PR TITLE
Heroku

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/client/package.json
+++ b/client/package.json
@@ -18,9 +18,7 @@
     "jwt-decode": "^3.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.10.0"
-  },
-  "devDependencies": {
+    "react-router-dom": "^6.10.0",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.1.0",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -13,6 +13,8 @@ import SearchResults from './pages/SearchResults';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 
+let inProduction = process.env.NODE_ENV === 'production';
+
 const authLink = setContext((_, { headers }) => {
   // get the authentication token from local storage if it exists
   const token = localStorage.getItem('id_token');
@@ -27,7 +29,7 @@ const authLink = setContext((_, { headers }) => {
 
 
 const client = new ApolloClient({
-  uri: 'http://127.0.0.1:3001/graphql',
+  uri: inProduction ? '/graphql':'http://127.0.0.1:3001/graphql',
   cache: new InMemoryCache(),
 });
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,5 @@
     "bcrypt": "^5.1.0",
     "dotenv": "^16.0.3",
     "jsonwebtoken": "^9.0.0"
-
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines":{
+    "node": ">=18.0.0"
+  },
   "devDependencies": {
     "concurrently": "^8.0.1",
     "eslint": "^7.9.0",

--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -1,5 +1,9 @@
 const mongoose = require('mongoose');
+require('dotenv').config();
 
+if(process.env.MONGODB_URI) {
+    mongoose.connect(process.env.MONGODB_URI);
+} else {
 mongoose.connect('mongodb://127.0.0.1:27017/gameboxd');
-
+}
 module.exports = mongoose.connection;


### PR DESCRIPTION
Adds functionality to deploy the site on Heroku
Adds ternary statement to App.jsx to just use /graphql as URI when in production
Adds if then statement to connection.js to connect to URI for Atlas cluster when that variable is truthy which should only apply when done through Heroku since that variable is only defined as a config var in the Heroku app's settings.

Also does some minor tweaks to the dependencies and dev dependencies for heroku.